### PR TITLE
Fix error log if the module is activated but not yet configured

### DIFF
--- a/storeggmap.php
+++ b/storeggmap.php
@@ -315,7 +315,7 @@ class Storeggmap extends Module implements WidgetInterface
         } else {
             $authorized_pages = array('stores');
         }
-        if ($authorized_pages && (in_array("*", $authorized_pages) || in_array($this->context->controller->php_self, $authorized_pages)) && !empty($apikey)) {
+        if (!empty($apikey) && $authorized_pages && (in_array("*", $authorized_pages) || in_array($this->context->controller->php_self, $authorized_pages))) {
             $this->context->controller->registerStylesheet('modules-ggmap', 'modules/'.$this->name.'/views/css/ggmap.css', ['media' => 'all', 'priority' => 150]);
             $this->context->controller->addJS('modules/'.$this->name.'/views/js/front-ggmap.js');
             Media::addJsDef(array(


### PR DESCRIPTION
We installed your module on a shop but we have lots of logs like this :

Uncaught exception 'ErrorException' with message 'in_array() expects parameter 2 to be array, bool given' in modules/storeggmap/storeggmap.php:282


I think configurations parameters are null and in_array throw an error.

I've just change the order of the condition and it looks like better.