### PR TITLE
Bugfix + EOL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,25 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Status: end of life — do not plan new work
+
+**This module is unmaintained as of August 2026.** Last release is 2.1.1, supporting **PrestaShop 1.7 to 8.x only**. It is not PS9 compatible and will not be made so — `ps_versions_compliancy` caps at `8.99.99` (`storeggmap.php:52`), which makes PS9 refuse the install.
+
+Do not propose or start PS9 compatibility work, dependency upgrades, or migrations off the deprecated Google Maps symbols (`google.maps.Marker`, `google.maps.places.Autocomplete`). Only certain, user-facing bugs get fixed, and only on request. The EOL notice lives in `README.md`; if that changes, update this file too.
+
 ## What this is
 
-`storeggmap` is a PrestaShop module (PS 1.7 through 9) that displays store lists on a Google Map, both on the front office store-locator page (via a Smarty widget) and on the back office `AdminModules` config page / `AdminOrders` order detail page (PS 8+ only). There is no build step, package manager, or test suite — it's plain PHP (PrestaShop module API) + vanilla ES6 JS + Smarty templates, edited directly on disk.
+`storeggmap` is a PrestaShop module that displays store lists on a Google Map, both on the front office store-locator page (via a Smarty widget) and on the back office `AdminModules` config page / `AdminOrders` order detail page (PS 8+ only). There is no build step, package manager, or test suite — it's plain PHP (PrestaShop module API) + vanilla ES6 JS + Smarty templates, edited directly on disk.
 
-This module is bind-mounted into the sibling PrestaShop-8 dev environment at `../../8/modules/storeggmap` (see `../../CLAUDE.md` for the Docker orchestration that runs it) — changes here are live in that container without a rebuild.
+This directory is bind-mounted into the sibling **PrestaShop 9** dev environment (`../../9/docker-compose.yml`, see `../../CLAUDE.md` for the orchestration) — but since the module now refuses to install on PS9, that container is only useful for reading files, not for testing. **To test a change, copy it into the running PS8 container**, which holds its own unmounted copy:
+
+```bash
+docker cp storeggmap.php ps8:/var/www/html/modules/storeggmap/storeggmap.php
+docker exec ps8 chown -R www-data:www-data /var/www/html/modules/storeggmap
+docker exec ps8 rm -rf /var/www/html/var/cache/*
+```
+
+Those copies are lost on `make reset-8`.
 
 ## No build/lint/test commands
 
@@ -17,7 +31,7 @@ There is nothing to run locally: no composer.json, no npm, no PHPUnit. Verify ch
 **Entry point**: `storeggmap.php` defines `Storeggmap extends Module implements WidgetInterface`. It registers three hooks:
 - `actionAdminControllerSetMedia` — loads back.css/back.js (or adminOrders.js on `AdminOrders`) + the Google Maps JS API + `StoreGgMap.js` class, only on the module's own config page or `AdminOrders`.
 - `actionFrontControllerSetMedia` — loads front.css/front.js + the Maps API on whichever front controllers are allowlisted in `STORE_GGMAP_PAGE` config (or all pages via `"*"`).
-- `displayAdminOrderSide` — (PS 8+) renders a small map in the order detail sidebar, geocoding the order's invoice/delivery address via the Google Geocoding API (`getCoordinateByAddress`) if `STORE_GGMAP_ADMIN_ORDER` is enabled.
+- `displayAdminOrderSide` — (PS 8+) renders a small map in the order detail sidebar if `STORE_GGMAP_ADMIN_ORDER` is enabled. It only flattens the order's invoice/delivery address to one line (`getAddressLiteral`) and passes it as `data-address`; the **geocoding happens in the browser** (`adminOrders.js`, `google.maps.Geocoder`). Don't move it back to PHP: a Maps key restricted by HTTP referrer — the normal setup, since the same key is exposed in the front office HTML — is rejected by the server-side Geocoding web service with `REQUEST_DENIED`. This `fetch()` is deliberately uncached, because its output varies per order.
 
 The front-office widget itself is rendered via `renderWidget()`/`getWidgetVariables()` (the `WidgetInterface` contract), fetching `views/templates/hook/storeggmap.tpl`, and is invoked from a shop template with `{widget name="storeggmap"}`.
 
@@ -26,7 +40,7 @@ The front-office widget itself is rendered via `renderWidget()`/`getWidgetVariab
 **AJAX backend**: `controllers/front/StoreInformation.php` (`StoreggmapStoreInformationModuleFrontController`) is the sole front-office AJAX endpoint, gated by a per-day CSRF-ish token (`$module->getToken()`, sha256 of cookie key + version + date, embedded via `Media::addJsDef` as `storeGgMmapSettings.token`). It dispatches `action` (`getStores`, `getStoreDetail`, `searchStoreByRadius`) — all POST-only, checked against an `allowedActions` allowlist. `searchStoreByRadius` runs a raw haversine-formula SQL query (`Db::getInstance()->executeS`) filtering PrestaShop's native `store` table by radius.
 
 **Front-end JS** (`views/js/`): `classes/StoreGgMap.js` is the single class driving the Google Map (`google.maps.Map`), used two ways:
-- `initBo()` — back office: single draggable/click-to-set marker, used both on the module config page (`back.js`) and read-only-ish on `AdminOrders` (`adminOrders.js`, seeded from the geocoded order address in `data-lat`/`data-lng` attributes).
+- `initBo()` — back office: single draggable/click-to-set marker, used both on the module config page (`back.js`) and read-only on `AdminOrders` (`adminOrders.js`, centred on the coordinates it geocodes itself from the `data-address` attribute; `initBo` skips its dblclick handler there, since the `ggmap_lat`/`ggmap_long` form fields only exist on the config page).
 - `initFo()` — front office (`front.js`): fetches all stores via AJAX, drops markers, wires click-to-show-detail (`InfoWindow` populated from `storeggmap_detail.tpl` fetched server-side), and optionally a Places Autocomplete search box (`initSearch`) that re-filters visible `.store-item` DOM elements by radius via `searchStoreByRadius`.
 
 Because `hookActionAdminControllerSetMedia` fires before Smarty `postProcess`, `back.js`/`adminOrders.js` re-read live form field values (`ggmap_lat`, `ggmap_long`, etc.) from the DOM on `window load` rather than trusting the settings baked in at hook time — don't remove that pattern when touching those files.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
+<h1>⚠️ Module en fin de vie — non maintenu / End of life — unmaintained</h1>
+<p>
+<strong>Ce module n'est plus maintenu depuis août 2026.</strong>
+La dernière version publiée est la <strong>2.1.1</strong>, compatible
+<strong>PrestaShop 1.7 à 8.x uniquement</strong>. Il n'est pas compatible
+PrestaShop 9 et ne le sera pas : à partir de la 2.1.1, le module refuse
+lui-même de s'installer sur PrestaShop 9.
+</p>
+<p>
+Aucun correctif de bug, aucune mise à jour de compatibilité et
+<strong>aucun correctif de sécurité</strong> ne sera publié. Les issues et
+les pull requests ne sont plus traitées.
+</p>
+<p>
+Le code reste disponible sous licence AFL-3.0 : vous êtes libre de le forker
+et de le reprendre à votre compte.
+</p>
+<hr/>
+<p>
+<em>
+This module is no longer maintained as of August 2026. The last released
+version is 2.1.1, supporting PrestaShop 1.7 to 8.x only — it is not, and will
+not become, PrestaShop 9 compatible. No bug fixes, no compatibility updates
+and no security fixes will be published; issues and pull requests are no
+longer handled. The code stays available under the AFL-3.0 license, so you are
+free to fork it.
+</em>
+</p>
+
 <h1>Show your store list on a google map - for PrestaShop 1.7 and higher</h1>
 <h2>About</h2>
 <p>Display a google map block fill with your store list.</p>
@@ -15,5 +44,10 @@
 </ol>
 <p>You can customize store info html by editing views/templates/front/storeggmap_detail.tpl</p>
 
-<h2>Contributing</h2>
-<p>PrestaShop modules are open-source extensions to the PrestaShop e-commerce solution. Everyone is welcome and even encouraged to contribute with their own improvements.</p>
+<h3>Google API key</h3>
+<p>
+The key must allow the <strong>Maps JavaScript API</strong>, and the
+<strong>Places API</strong> if you enable the search box. Geocoding is done
+from the browser, so an HTTP referrer restriction on the key is enough — a
+server-side key restriction is not required.
+</p>

--- a/_scripts/buildzip.sh
+++ b/_scripts/buildzip.sh
@@ -26,8 +26,17 @@ trap 'rm -rf "$BUILD_ROOT"' EXIT
 BUILD_DIR="$BUILD_ROOT/$MODULE_NAME"
 mkdir -p "$BUILD_DIR"
 
+# Fichiers suivis par git mais sans utilite dans un module installe en production :
+# doc interne, outillage de release et archives des versions precedentes.
+EXCLUDES=(
+    ':(exclude)CLAUDE.md'
+    ':(exclude).gitignore'
+    ':(exclude)_scripts/'
+    ':(exclude)_versions/'
+)
+
 cd "$MODULE_DIR"
-git ls-files -z | xargs -0 -I{} sh -c 'mkdir -p "$1/$(dirname "$2")" && cp "$2" "$1/$2"' _ "$BUILD_DIR" {}
+git ls-files -z -- "${EXCLUDES[@]}" | xargs -0 -I{} sh -c 'mkdir -p "$1/$(dirname "$2")" && cp "$2" "$1/$2"' _ "$BUILD_DIR" {}
 
 mkdir -p "$OUTPUT_DIR"
 

--- a/controllers/front/StoreInformation.php
+++ b/controllers/front/StoreInformation.php
@@ -127,13 +127,17 @@ class StoreggmapStoreInformationModuleFrontController extends ModuleFrontControl
     private function searchStoreByRadius()
     {
         $radius = (int)Tools::getValue('radius', 15);
-        $lat = (float)Tools::getValue('lat', null);
-        $lng = (float)Tools::getValue('lng', null);
-        
-        if (empty($lat) || empty($lng)) {
+        $lat = Tools::getValue('lat');
+        $lng = Tools::getValue('lng');
+
+        ## empty() rejetterait la latitude 0 (equateur) et la longitude 0 (meridien de Greenwich)
+        if (!is_numeric($lat) || !is_numeric($lng)) {
             return [];
         }
-        
+
+        $lat = (float)$lat;
+        $lng = (float)$lng;
+
         $distance_unit = Configuration::get('PS_DISTANCE_UNIT');
         if (!in_array($distance_unit, ['km', 'mi'])) {
             $distance_unit = 'km';
@@ -144,17 +148,20 @@ class StoreggmapStoreInformationModuleFrontController extends ModuleFrontControl
         $stores = Db::getInstance()->executeS('SELECT s.id_store,
                                                 (' . (int)$multiplicator . '
                                                     * acos(
-                                                        cos(radians(' . (float)$lat . '))
-                                                        * cos(radians(latitude))
-                                                        * cos(radians(longitude) - radians(' . (float)$lng . '))
-                                                        + sin(radians(' . (float)$lat . '))
-                                                        * sin(radians(latitude))
+                                                        LEAST(1,
+                                                            cos(radians(' . (float)$lat . '))
+                                                            * cos(radians(s.latitude))
+                                                            * cos(radians(s.longitude) - radians(' . (float)$lng . '))
+                                                            + sin(radians(' . (float)$lat . '))
+                                                            * sin(radians(s.latitude))
+                                                        )
                                                     )
                                                 ) distance
                                                 FROM ' . _DB_PREFIX_ . 'store s
                                                 ' . Shop::addSqlAssociation('store', 's') . '
                                                 WHERE s.active = 1
-                                                HAVING CAST(distance AS UNSIGNED) > ' . (int)$radius . '
+                                                AND (s.latitude != 0 OR s.longitude != 0)
+                                                HAVING distance <= ' . (int)$radius . '
                                                 ORDER BY distance ASC');
         if (!empty($stores)) {
             $stores = array_column($stores, 'id_store');

--- a/controllers/front/index.php
+++ b/controllers/front/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/controllers/index.php
+++ b/controllers/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/index.php
+++ b/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/storeggmap.php
+++ b/storeggmap.php
@@ -1,29 +1,11 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2024 awb-dsgn.com
-
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+/**
+ * storeggmap - Show your stores on a Google Map
+ *
+ * @author    Arnaud Drieux <contact@awb-dsgn.com>
+ * @copyright 2026 awb-dsgn.com
+ * @license   https://opensource.org/licenses/AFL-3.0 AFL-3.0
+ */
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -66,7 +48,7 @@ class Storeggmap extends Module implements WidgetInterface
         $this->displayName = $this->l('Show your stores on a google map');
         $this->description = $this->l('Add Google map on the store page');
 
-        $this->ps_versions_compliancy = array('min' => '1.7.0.0', 'max' => '9.99.99');
+        $this->ps_versions_compliancy = array('min' => '1.7.0.0', 'max' => '8.99.99');
 
         $this->templateFile = 'module:storeggmap/views/templates/hook/storeggmap.tpl';
         $this->templateDetailFile = 'module:storeggmap/views/templates/front/storeggmap_detail.tpl';

--- a/storeggmap.php
+++ b/storeggmap.php
@@ -600,44 +600,46 @@ class Storeggmap extends Module implements WidgetInterface
             return;
         }
         
-        $coordinate = new stdClass();
-        $coordinate->lng = null;
-        $coordinate->lat = null;
-        
+        $addressLiteral = '';
+
         if('AdminOrders' == $this->context->controller->controller_name)
         {
             $order = new Order((int) $params['id_order']);
-            
+
             $id_address = $order->id_address_delivery;
             if(static::$ADDRESS_INVOICE_CHOICE == (int)Configuration::get('STORE_GGMAP_ADMIN_ORDER_ADDRESS_CHOICE'))
             {
                 $id_address = $order->id_address_invoice;
             }
-            
+
             if($id_address)
             {
-                $address = new Address($id_address);
-                $coordinateFromApi = $this->getCoordinateByAddress($address);
-                if($coordinateFromApi)
-                {
-                    $coordinate = $coordinateFromApi;
-                }
-            }           
+                $addressLiteral = $this->getAddressLiteral(new Address($id_address));
+            }
         }
-        
+
         $this->smarty->assign([
-            'storeGgMapOrderAddressCoordinate' => $coordinate
+            'storeGgMapOrderAddress' => $addressLiteral
         ]);
-        
-        return $this->fetch('module:storeggmap/views/templates/hook/admin_order_side.tpl', $this->getCacheId('storeggmap'));
+
+        ## Pas de cache : le rendu depend de la commande affichee, un id de cache
+        ## constant servirait l'adresse de la premiere commande a toutes les autres.
+        return $this->fetch('module:storeggmap/views/templates/hook/admin_order_side.tpl');
     }
-    
-    private function getCoordinateByAddress(Address $address)
+
+    /**
+     * Assemble l'adresse sur une ligne, telle qu'elle sera envoyee au geocodeur.
+     * Le geocodage lui-meme se fait dans le navigateur (views/js/adminOrders.js) :
+     * une cle Maps restreinte par referent HTTP est refusee par le web service
+     * Geocoding, qui est appele sans referent depuis le serveur.
+     */
+    private function getAddressLiteral(Address $address)
     {
-        if(!$address)
+        if(!$address->id)
         {
-            return false;
+            return '';
         }
+
         $addressLiteral = [$address->address1];
         $addressLiteral[] = $address->address2;
         $addressLiteral[] = $address->postcode;
@@ -646,28 +648,8 @@ class Storeggmap extends Module implements WidgetInterface
         if($address->id_state){
             $addressLiteral[] = State::getNameById($address->id_state);
         }
-        
-        $query = [
-            'address' => urlencode(implode(' ',$addressLiteral)),
-            'key' => Configuration::get('STORE_GGMAP_APIKEY')
-        ];
-        $params = '?' . http_build_query($query);
-        
-        $fullUrl = 'https://maps.googleapis.com/maps/api/geocode/json'.$params;
-        
-        $data = Tools::file_get_contents($fullUrl);
-        if(!$data)
-        {
-            return false;
-        }
-        
-        $data = json_decode($data);
-        if($data->status !== 'OK')
-        {
-            return false;
-        }
-        
-        return $data->results[0]->geometry->location;
+
+        return trim(implode(' ', array_filter($addressLiteral)));
     }
     
     private function getApiUrl($withSearch = false)

--- a/storeggmap.php
+++ b/storeggmap.php
@@ -39,7 +39,7 @@ class Storeggmap extends Module implements WidgetInterface
     {
         $this->name = 'storeggmap';
         $this->author = 'Arnaud Drieux';
-        $this->version = '2.1.0';
+        $this->version = '2.1.1';
         $this->need_instance = 0;
 
         $this->bootstrap = true;

--- a/translations/index.php
+++ b/translations/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/upgrade/upgrade-2.0.0.php
+++ b/upgrade/upgrade-2.0.0.php
@@ -1,28 +1,11 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+/**
+ * storeggmap - Show your stores on a Google Map
+ *
+ * @author    Arnaud Drieux <contact@awb-dsgn.com>
+ * @copyright 2026 awb-dsgn.com
+ * @license   https://opensource.org/licenses/AFL-3.0 AFL-3.0
+ */
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/upgrade/upgrade-2.1.0.php
+++ b/upgrade/upgrade-2.1.0.php
@@ -1,28 +1,11 @@
 <?php
-/*
-* 2007-2024 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+/**
+ * storeggmap - Show your stores on a Google Map
+ *
+ * @author    Arnaud Drieux <contact@awb-dsgn.com>
+ * @copyright 2026 awb-dsgn.com
+ * @license   https://opensource.org/licenses/AFL-3.0 AFL-3.0
+ */
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/views/css/index.php
+++ b/views/css/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/img/index.php
+++ b/views/img/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/index.php
+++ b/views/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/js/adminOrders.js
+++ b/views/js/adminOrders.js
@@ -1,9 +1,17 @@
 window.addEventListener("load", (event) => {
-    
-    storeGgMmapSettings.defaultLatitude = parseFloat(document.getElementById("ggmap").dataset.lat);
-    storeGgMmapSettings.defaultLongitude = parseFloat(document.getElementById("ggmap").dataset.lng);
+    /**
+     Ce fichier est charge sur tout AdminOrders, liste comprise, et le template
+     n'affiche rien quand le geocodage echoue : le conteneur est souvent absent.
+     */
+    const mapContainer = document.getElementById("ggmap");
+    if (!mapContainer) {
+        return;
+    }
+
+    storeGgMmapSettings.defaultLatitude = parseFloat(mapContainer.dataset.lat);
+    storeGgMmapSettings.defaultLongitude = parseFloat(mapContainer.dataset.lng);
     storeGgMmapSettings.defaultZoom = 10;
-    
+
     if(!isNaN(storeGgMmapSettings.defaultLatitude) && !isNaN(storeGgMmapSettings.defaultLongitude)) {
         const storeggmap = new StoreGgMap('ggmap', storeGgMmapSettings);
         storeggmap.initBo();

--- a/views/js/adminOrders.js
+++ b/views/js/adminOrders.js
@@ -1,20 +1,42 @@
-window.addEventListener("load", (event) => {
+window.addEventListener("load", async (event) => {
     /**
      Ce fichier est charge sur tout AdminOrders, liste comprise, et le template
-     n'affiche rien quand le geocodage echoue : le conteneur est souvent absent.
+     n'affiche rien quand l'adresse de la commande est vide : le conteneur est souvent absent.
      */
     const mapContainer = document.getElementById("ggmap");
     if (!mapContainer) {
         return;
     }
 
-    storeGgMmapSettings.defaultLatitude = parseFloat(mapContainer.dataset.lat);
-    storeGgMmapSettings.defaultLongitude = parseFloat(mapContainer.dataset.lng);
+    const address = mapContainer.dataset.address;
+    if (!address) {
+        return;
+    }
+
+    /**
+     Le geocodage se fait ici, dans le navigateur, et non cote PHP : une cle Maps
+     restreinte par referent HTTP est refusee par le web service Geocoding
+     (REQUEST_DENIED), qui recoit une requete serveur donc sans referent.
+     Le service JS, lui, porte le referent de la page et passe avec la meme cle.
+     */
+    let location = null;
+    try {
+        const response = await new google.maps.Geocoder().geocode({address: address});
+        if (response.results.length) {
+            location = response.results[0].geometry.location;
+        }
+    } catch (error) {
+        console.error("storeggmap - geocodage de l'adresse de la commande impossible :", error);
+    }
+
+    if (!location) {
+        return;
+    }
+
+    storeGgMmapSettings.defaultLatitude = location.lat();
+    storeGgMmapSettings.defaultLongitude = location.lng();
     storeGgMmapSettings.defaultZoom = 10;
 
-    if(!isNaN(storeGgMmapSettings.defaultLatitude) && !isNaN(storeGgMmapSettings.defaultLongitude)) {
-        const storeggmap = new StoreGgMap('ggmap', storeGgMmapSettings);
-        storeggmap.initBo();
-    }
+    const storeggmap = new StoreGgMap('ggmap', storeGgMmapSettings);
+    storeggmap.initBo();
 });
-

--- a/views/js/classes/StoreGgMap.js
+++ b/views/js/classes/StoreGgMap.js
@@ -10,6 +10,7 @@ class StoreGgMap {
         this.defaultZoom = settings.defaultZoom
         this.designCustomization = settings.designCustomization
         this.searchEnable = settings.searchEnable
+        this.searchErrorMessage = settings.searchErrorMessage
         this.idLang = settings.id_lang
         this.infowindow = null
         this.ratioRadiusZoom = {
@@ -105,7 +106,7 @@ class StoreGgMap {
     initSearch() {
         const locationInput = document.getElementById("location_input")
         const locationOptions = {
-            fields: ["geometry"],
+            fields: ["geometry", "name"],
             origin: this.map.getCenter()
         }
         const locationAutocomplete = new google.maps.places.Autocomplete(
@@ -118,7 +119,7 @@ class StoreGgMap {
             const place = locationAutocomplete.getPlace()
 
             if (!place.geometry || !place.geometry.location) {
-                window.alert(no_data_address_message + " '" + place.name + "'")
+                window.alert(this.searchErrorMessage + " '" + (place.name || locationInput.value) + "'")
                 return
             }
 

--- a/views/js/classes/StoreGgMap.js
+++ b/views/js/classes/StoreGgMap.js
@@ -45,10 +45,21 @@ class StoreGgMap {
             longitude: this.defaultLongitude
         })
 
+        const latInput = document.getElementById("ggmap_lat")
+        const lngInput = document.getElementById("ggmap_long")
+
+        /**
+         Ces champs appartiennent au formulaire de configuration du module.
+         Sur la fiche commande ils n'existent pas : la carte y reste en lecture seule.
+         */
+        if (!latInput || !lngInput) {
+            return
+        }
+
         this.map.addListener('dblclick', (event) => {
             this.hideMarkers()
-            document.getElementById("ggmap_lat").value = event.latLng.lat()
-            document.getElementById("ggmap_long").value = event.latLng.lng()
+            latInput.value = event.latLng.lat()
+            lngInput.value = event.latLng.lng()
             this.addMarker({
                 latitude: event.latLng.lat(),
                 longitude: event.latLng.lng()

--- a/views/js/classes/index.php
+++ b/views/js/classes/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/js/index.php
+++ b/views/js/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 PrestaShop SA
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/templates/front/index.php
+++ b/views/templates/front/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/templates/front/storeggmap_detail.tpl
+++ b/views/templates/front/storeggmap_detail.tpl
@@ -1,27 +1,10 @@
 {*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*}
+ * storeggmap - Show your stores on a Google Map
+ *
+ * @author    Arnaud Drieux <contact@awb-dsgn.com>
+ * @copyright 2026 awb-dsgn.com
+ * @license   https://opensource.org/licenses/AFL-3.0 AFL-3.0
+ *}
 
 <div class="store_infos">
     <p><b>{$store->name}</b></p>

--- a/views/templates/hook/admin_order_side.tpl
+++ b/views/templates/hook/admin_order_side.tpl
@@ -1,9 +1,9 @@
-{if isset($storeGgMapOrderAddressCoordinate->lng) && isset($storeGgMapOrderAddressCoordinate->lat)}
+{if $storeGgMapOrderAddress}
 <div class="card mt-2" data-role="message-card">
     <div class="card-body">
         <div class="row">
             <div class="col-md-12">
-                <div id="ggmap" style="height:300px;" data-lng="{$storeGgMapOrderAddressCoordinate->lng}" data-lat="{$storeGgMapOrderAddressCoordinate->lat}"></div>
+                <div id="ggmap" style="height:300px;" data-address="{$storeGgMapOrderAddress|escape:'html':'UTF-8'}"></div>
             </div>
         </div>
     </div>

--- a/views/templates/hook/index.php
+++ b/views/templates/hook/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');

--- a/views/templates/hook/storeggmap.tpl
+++ b/views/templates/hook/storeggmap.tpl
@@ -1,27 +1,10 @@
 {*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*}
+ * storeggmap - Show your stores on a Google Map
+ *
+ * @author    Arnaud Drieux <contact@awb-dsgn.com>
+ * @copyright 2026 awb-dsgn.com
+ * @license   https://opensource.org/licenses/AFL-3.0 AFL-3.0
+ *}
 
 <section id="map-style">
     {if $apiKey}

--- a/views/templates/index.php
+++ b/views/templates/index.php
@@ -1,28 +1,5 @@
 <?php
-/*
-* 2007-2023 PrestaShop
-*
-* NOTICE OF LICENSE
-*
-* This source file is subject to the Academic Free License (AFL 3.0)
-* that is bundled with this package in the file LICENSE.txt.
-* It is also available through the world-wide-web at this URL:
-* http://opensource.org/licenses/afl-3.0.php
-* If you did not receive a copy of the license and are unable to
-* obtain it through the world-wide-web, please send an email
-* to license@prestashop.com so we can send you a copy immediately.
-*
-* DISCLAIMER
-*
-* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
-* versions in the future. If you wish to customize PrestaShop for your
-* needs please refer to http://www.prestashop.com for more information.
-*
-*  @author Arnaud Drieux <contact@awb-dsgn.com>
-*  @copyright  2007-2023 awb-dsgn.com
-*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
-*  International Registered Trademark & Property of PrestaShop SA
-*/
+// Protection contre l'indexation de repertoire - AFL-3.0, awb-dsgn.com
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');


### PR DESCRIPTION
Branche de fin de vie du module : 
simplification des en-têtes de licence (510 suppressions pour 213 ajouts sur l'ensemble des fichiers), puis correction des cinq bugs fonctionnels certains relevés à l'audit :
- l'inversion du filtre de recherche par rayon dans la requête haversine 
- la variable inexistante dans le message d'erreur de recherche 
- le crash JS sur la liste des commandes
- le crash au double-clic sur la carte d'une fiche commande
- la carte absente du back-office commande dont le géocodage serveur était refusé par Google faute de référent, désormais fait dans le navigateur

Complétée par la déclaration officielle du statut non maintenu dans le README et CLAUDE.md.
Le plafond de compatibilité ramené à PrestaShop 8.x, et l'exclusion de la doc interne et de l'outillage de release du zip de production.